### PR TITLE
Add Mac release

### DIFF
--- a/release/mac/.gitignore
+++ b/release/mac/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!setup.sh
+!start.sh

--- a/release/mac/setup.sh
+++ b/release/mac/setup.sh
@@ -1,0 +1,13 @@
+rm -rf "app"
+rm server
+
+wget https://github.com/project-papa/project-papa-server/releases/download/0.0.1/server
+chmod +x ./server
+
+wget http://sonic-pi.net/files/releases/v2.11.1/Sonic-Pi-for-Mac-v2.11.1.dmg
+
+hdiutil mount Sonic-Pi-for-Mac-v2.11.1.dmg
+cp -R "/Volumes/Sonic Pi v2.11.1/Sonic Pi.app" ./app
+
+hdiutil unmount "/Volumes/Sonic Pi v2.11.1"
+rm Sonic-Pi-for-Mac-v2.11.1.dmg

--- a/release/mac/start.sh
+++ b/release/mac/start.sh
@@ -1,0 +1,4 @@
+{
+  (sleep 2s; ./server) &
+  ./app/server/native/osx/ruby/bin/ruby ./app/server/bin/sonic-pi-server.rb;
+}


### PR DESCRIPTION
This adds a simple script to get setup on Mac with Sonic Pi and the server.

One simply needs to run `setup.sh` the first time, and then `start.sh` to run the thing.
