### PR TITLE
Make the scope reader more stable

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -8,7 +8,12 @@ target_link_libraries(server osc_interface)
 target_link_libraries(server websockets_interface)
 target_link_libraries(server scope_interface)
 
-target_link_libraries(server pthread)
+if(UNIX)
+    target_link_libraries(server pthread)
+    if(NOT APPLE)
+        target_link_libraries(server rt)
+    endif()
+endif()
 
 target_link_libraries(server ${Boost_LIBRARIES})
 target_link_libraries(server ${OPENSSL_LIBRARIES})

--- a/src/main/include/pi_subscriptions.h
+++ b/src/main/include/pi_subscriptions.h
@@ -62,6 +62,9 @@ class pi_subscriptions {
                     a.SetObject();
 
                     std::vector<unsigned int> scopes = get_scopes();
+                    if (scopes.size() == 0) {
+                        continue;
+                    }
 
                     bool has_members = false;
 

--- a/src/main/include/pi_subscriptions.h
+++ b/src/main/include/pi_subscriptions.h
@@ -89,8 +89,6 @@ class pi_subscriptions {
                     std::string json_string(buffer.GetString());
                     ws->broadcast_message(json_string);
 
-                    std::cout << json_string << "\n";
-
                     #ifdef _WIN32
                     Sleep(delay);
                     #else

--- a/src/main/include/pi_websocket_server.h
+++ b/src/main/include/pi_websocket_server.h
@@ -69,6 +69,12 @@ class pi_ws_server : public server {
             }
         }
 
+        void on_close(connection c, int s, const std::string& r) {
+            oscpkt::Message m("/stop-all-jobs");
+            m.pushStr(GUI_ID);
+            sender.send_osc(m);
+        }
+
         osc_sender sender;
         std::unique_ptr<pi_subscriptions> subs;
 };

--- a/src/websockets/include/server.h
+++ b/src/websockets/include/server.h
@@ -53,6 +53,16 @@ class server {
          */
         virtual void on_message(connection conn, message msg);
 
+        /**
+         * Event handler for a websocket closing.
+         * Can be overridden in subclasses to provide different behavior.
+         * @param conn connection handler of the socket that sent the message
+         * @param status status code (see RFC 6455 7.4.1)
+         * @param reason the reason for disconnection
+         */
+        virtual void on_close(connection conn, int status,
+            const std::string& reason);
+
         ws_server wss;
 
     private:

--- a/src/websockets/src/server.cpp
+++ b/src/websockets/src/server.cpp
@@ -9,6 +9,12 @@ server::server(int port) {
     default_endpoint.on_message = [this] (connection conn, message msg) {
         this->on_message(conn, msg);
     };
+
+    default_endpoint.on_close =
+        [this] (
+            connection conn, int status, const std::string& reason) {
+        this->on_close(conn, status, reason);
+    };
 }
 
 server::~server() {
@@ -48,4 +54,9 @@ void server::on_message(connection conn, message msg) {
     auto send_stream = std::make_shared<ws_server::SendStream>();
     *send_stream << message_str;
     wss.send(conn, send_stream);
+}
+
+void server::on_close(
+    connection conn, int status, const std::string& reason) {
+    // do nothing - stub method
 }


### PR DESCRIPTION
The scope reader will now reconnect after too many failed reads, and also will avoid sending unnecessary messages to the connected websockets.